### PR TITLE
Steps flag

### DIFF
--- a/src/llstep/_llstep.py
+++ b/src/llstep/_llstep.py
@@ -75,6 +75,7 @@ class Step:
         # name, this actually overrides the old function with the new one
         exec(compile(out_tree, "<string>", "exec"), func_scope)
         self.f = func_scope[new_func_name]
+        #self.f.IsStep = True
 
 
 class StepRewriter(NodeTransformer):
@@ -159,7 +160,14 @@ class StepBodyRewriter(NodeTransformer):
         if resolved_callable is None:
             return call
         if not isinstance(resolved_callable, Step):
-            return call
+            if hasattr(resolved_callable, "IsStep"):
+                new_args = [copy_location(Name("context", Load()), call)]
+                new_args.extend(call.args)
+                return fix_missing_locations(
+                    copy_location(Call(call.func, new_args, call.keywords), call)
+                )
+            else:
+                return call
         # if it's a step, rewrite
         new_args = [copy_location(Name("context", Load()), call)]
         new_args.extend(call.args)

--- a/src/llstep/_llstep.py
+++ b/src/llstep/_llstep.py
@@ -75,7 +75,7 @@ class Step:
         # name, this actually overrides the old function with the new one
         exec(compile(out_tree, "<string>", "exec"), func_scope)
         self.f = func_scope[new_func_name]
-        #self.f.IsStep = True
+        self.f.IsStep = True
 
 
 class StepRewriter(NodeTransformer):

--- a/tests/test_rewrite.py
+++ b/tests/test_rewrite.py
@@ -135,3 +135,25 @@ def test_nested_step_calls():
     another_step_was_called = False
     calls_another_step()
     assert another_step_was_called == True
+
+
+@step
+def step_one():
+    print("I ran")
+
+
+@step
+def step_two():
+    step_one()
+
+
+@script
+def the_script():
+    step_one()
+    step_two()
+
+
+def test_another_test_of_nested_script_calls():
+    """This test proves that nested step calls are being properly handled within a
+    script."""
+    the_script()


### PR DESCRIPTION
This method of tracking rewritten steps just sets an attribute flag in the Steps.rewrite phase and then is checked later on in the StepBodyRewriter.visit_Call.

This may or may not translate well when Jit comes in to the mix, but for now it's a relatively clean solution that's at least passing my tests I throw its way.